### PR TITLE
Pad page numbers to ensure consistent order

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -277,7 +277,7 @@ func (comic *Comic) makeCBRZ() error {
 				return err
 			}
 			// create a tempfile to store the image
-			tmpfile, err := ioutil.TempFile(tempDir, fmt.Sprintf("%d-image.*.%s", i, tp))
+			tmpfile, err := ioutil.TempFile(tempDir, fmt.Sprintf("%04d-image.*.%s", i, tp))
 			defer os.Remove(tmpfile.Name()) // clean up
 
 			if err != nil {


### PR DESCRIPTION
In some CBZ readers the order of files is alphabetical so that pages 1-11 would be ordered 1, 10, 11, 2, 3 ...

For a specific example see https://forum.xda-developers.com/showthread.php?t=1076777 (which may be discontinued, apparently)