### PR TITLE
MangaDex: Add "download all" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 ## Supported Sites
 
-- http://www.comicextra.com/
+- https://www.comicextra.com/
 - https://mangarock.com/
 - https://www.mangareader.net/
-- http://www.mangatown.com/
+- https://www.mangatown.com/
 - https://mangadex.org/
 
 ## Getting Started
@@ -45,7 +45,7 @@ You can invoke the `--help`:
   -all
         Download all issues of the Comic or Comics
   -country string
-        Set the country to retrieve a manga, Used by MangaRock
+        Set the country to retrieve a manga, Used by MangaRock and MangaDex
   -daemon
         Run the download as daemon
   -format string
@@ -74,7 +74,7 @@ You can invoke the `--help`:
 |https://mangarock.com/       |&#x2713;|&#x2713;|&#x2713;|
 |https://www.mangareader.net/ |&#x2713;|&#x2717;|&#x2713;|
 |http://www.mangatown.com/    |&#x2713;|&#x2717;|&#x2713;|
-|https://mangadex.org/        |&#x2717;|&#x2717;|&#x2717;|
+|https://mangadex.org/        |&#x2713;|&#x2713;|&#x2717;|
 
 
 ### Checking for mangas using a Raspberry Pi

--- a/cmd/app/downloader.go
+++ b/cmd/app/downloader.go
@@ -57,11 +57,10 @@ func download(link, format, country string, all, last, bindLogsToChannel, images
 				continue
 			}
 
-			if strings.Contains(source, "mangadex") && (all || last) {
-				msg := "`all` and `last` parameters are not supported"
+			if strings.Contains(source, "mangadex") && (last) {
+				msg := "`last` parameters are not supported"
 				log.WithFields(log.Fields{"site": u}).Warning(msg)
 				sendToChannel(bindLogsToChannel, msg)
-				all = false
 				last = false
 			}
 

--- a/cmd/app/downloader.go
+++ b/cmd/app/downloader.go
@@ -58,7 +58,7 @@ func download(link, format, country string, all, last, bindLogsToChannel, images
 			}
 
 			if strings.Contains(source, "mangadex") && (last) {
-				msg := "`last` parameters are not supported"
+				msg := "`last` parameter is not supported"
 				log.WithFields(log.Fields{"site": u}).Warning(msg)
 				sendToChannel(bindLogsToChannel, msg)
 				last = false

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -62,7 +62,7 @@ func LoadComicFromSource(source, url, country, format, imagesFormat string, all,
 	case "www.mangatown.com":
 		siteSource = &Mangatown{}
 	case "mangadex.org":
-		siteSource = NewMangadex()
+		siteSource = NewMangadex(country)
 	default:
 		err = fmt.Errorf("It was not possible to determine the source")
 		return collection, err

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -1,6 +1,7 @@
 package sites
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Girbons/comics-downloader/pkg/core"
@@ -9,13 +10,15 @@ import (
 )
 
 type Mangadex struct {
-	Client *mangadex.Client
+	country string
+	Client  *mangadex.Client
 }
 
 // NewMangadex returns a Mangadex instance
-func NewMangadex() *Mangadex {
+func NewMangadex(country string) *Mangadex {
 	return &Mangadex{
-		Client: mangadex.New(),
+		country: country,
+		Client:  mangadex.New(),
 	}
 }
 
@@ -36,7 +39,32 @@ func (m *Mangadex) getLinks(url string) ([]string, error) {
 }
 
 func (m *Mangadex) RetrieveIssueLinks(url string, all, last bool) ([]string, error) {
-	return []string{url}, nil
+	parts := util.TrimAndSplitURL(url)
+	switch parts[3] {
+	case "chapter":
+		return []string{url}, nil
+	case "title":
+		_, cs, err := m.Client.Manga(parts[4])
+		if err != nil {
+			return nil, err
+		}
+		var urls []string
+		for _, c := range cs {
+			if m.country != "" && c.LangCode != m.country {
+				continue
+			}
+			urls = append(urls, "https://mangadex.org/chapter/"+c.ID.String())
+		}
+		if len(urls) == 0 {
+			return nil, errors.New("no chapters found")
+		}
+		if last {
+			urls = urls[:1]
+		}
+		return urls, nil
+	default:
+		return nil, errors.New("URL not supported")
+	}
 }
 
 func (m *Mangadex) GetInfo(url string) (string, string) {

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -58,9 +58,6 @@ func (m *Mangadex) RetrieveIssueLinks(url string, all, last bool) ([]string, err
 		if len(urls) == 0 {
 			return nil, errors.New("no chapters found")
 		}
-		if last {
-			urls = urls[:1]
-		}
 		return urls, nil
 	default:
 		return nil, errors.New("URL not supported")

--- a/pkg/sites/mangadex_test.go
+++ b/pkg/sites/mangadex_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMangadexGetInfo(t *testing.T) {
-	md := NewMangadex()
+	md := NewMangadex("")
 
 	name, issueNumber := md.GetInfo("https://mangadex.org/chapter/155061/1")
 	assert.Equal(t, "Naruto", name)
@@ -16,7 +16,7 @@ func TestMangadexGetInfo(t *testing.T) {
 }
 
 func TestMangadexSetup(t *testing.T) {
-	md := NewMangadex()
+	md := NewMangadex("")
 	comic := new(core.Comic)
 
 	comic.URLSource = "https://mangadex.org/chapter/155061/1"
@@ -28,7 +28,7 @@ func TestMangadexSetup(t *testing.T) {
 }
 
 func TestMangadexRetrieveIssueLinks(t *testing.T) {
-	md := NewMangadex()
+	md := NewMangadex("")
 
 	issues, err := md.RetrieveIssueLinks("https://mangadex.org/chapter/155061/1", false, false)
 


### PR DESCRIPTION
Hi, I've added the option to download all chapters of a manga from MangaDex. But before considering merging this, there are a few questions:

It currently switches between "download one chapter" and "download all chapters" based on the given URL. For example, if you pass `mangadex.org/title/123`, it'll download all and if you pass `mangadex.org/chapter/123` it'll just download one chapter. How should it, for example, behave, if one doesn't set the `-all` flag but passes a manga URL?

Another problem are different languages: It uses the same flag as MangaRock ( `-country`), but expects "language codes" like `gb` or `sa` instead of names. Should this be translated internally or would it be enought to note it in the readme?

Hope this helps #41.