### PR TITLE
MangaDex: Add -last flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can invoke the `--help`:
 |https://mangarock.com/       |&#x2713;|&#x2713;|&#x2713;|
 |https://www.mangareader.net/ |&#x2713;|&#x2717;|&#x2713;|
 |http://www.mangatown.com/    |&#x2713;|&#x2717;|&#x2713;|
-|https://mangadex.org/        |&#x2713;|&#x2713;|&#x2717;|
+|https://mangadex.org/        |&#x2713;|&#x2713;|&#x2713;|
 
 
 ### Checking for mangas using a Raspberry Pi

--- a/cmd/app/downloader.go
+++ b/cmd/app/downloader.go
@@ -57,13 +57,6 @@ func download(link, format, country string, all, last, bindLogsToChannel, images
 				continue
 			}
 
-			if strings.Contains(source, "mangadex") && (last) {
-				msg := "`last` parameter is not supported"
-				log.WithFields(log.Fields{"site": u}).Warning(msg)
-				sendToChannel(bindLogsToChannel, msg)
-				last = false
-			}
-
 			msg := "Downloading..."
 			log.WithFields(log.Fields{"url": u}).Info(msg)
 			sendToChannel(bindLogsToChannel, msg)

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.12
 
 require (
 	fyne.io/fyne v1.1.1
-	github.com/BakeRolls/mri v0.0.0-20190425192657-438a0b611ec0
 	github.com/Girbons/mangarock v0.0.0-20190725180316-ca97fc422a34
 	github.com/anaskhan96/soup v1.1.1
-	github.com/bake/mangadex v0.0.0-20190918122836-0261a89dc30d
+	github.com/bake/mangadex v0.0.0-20191208094511-1b8be9f2df20
+	github.com/bake/mri v0.0.0-20190425192657-438a0b611ec0
 	github.com/bmaupin/go-epub v0.5.3
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/frankban/quicktest v1.4.1 // indirect
@@ -16,7 +16,6 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/nwaples/rardecode v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
-	github.com/schollz/progressbar v1.0.0
 	github.com/schollz/progressbar/v2 v2.13.2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 fyne.io/fyne v1.1.1 h1:vmeT7lqdho+Upt/PWuDInj8xAkNAaZC/rbtr3goJczY=
 fyne.io/fyne v1.1.1/go.mod h1:mz0CvQX1ACEjiDGpSH3D8Qf9yHq8dfYA039kG7p8ZhQ=
-github.com/BakeRolls/mri v0.0.0-20190425192657-438a0b611ec0 h1:c+QNUfCT1Zu0fwRMFEiKgCsYiEF13HGsWf47VMtAtbw=
-github.com/BakeRolls/mri v0.0.0-20190425192657-438a0b611ec0/go.mod h1:lYbZQJuNWU9Fhp922h0f8H949KuqSRjnh19lUgK9dlQ=
 github.com/Girbons/mangarock v0.0.0-20190725180316-ca97fc422a34 h1:xA3kIurxuPIBtdLe8OCmsVTsxx+yDAYPKIYhOhLzE74=
 github.com/Girbons/mangarock v0.0.0-20190725180316-ca97fc422a34/go.mod h1:4JwFTbX7V1Cm/RtPspR8JAoOYGcdMBNoKtku4m6B85c=
 github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9/go.mod h1:7uhhqiBaR4CpN0k9rMjOtjpcfGd6DG2m04zQxKnWQ0I=
@@ -12,6 +10,10 @@ github.com/bake/httpcache v0.0.0-20190425194625-775d0adac809 h1:+WthOY6+9RdivM1S
 github.com/bake/httpcache v0.0.0-20190425194625-775d0adac809/go.mod h1:4NG8FC+Gt0aSRAFe+GcCsKUGCL63u0doQyQBQffWX90=
 github.com/bake/mangadex v0.0.0-20190918122836-0261a89dc30d h1:WpnqIe+TLGBW+cHHm2SA8lwlCtIMYhWNl2H+Z0peTJM=
 github.com/bake/mangadex v0.0.0-20190918122836-0261a89dc30d/go.mod h1:0EIa3RFRprO7Ey+7O0TveUY6epgxsabT82R3bkUjkzU=
+github.com/bake/mangadex v0.0.0-20191208094511-1b8be9f2df20 h1:QrnRIo2F6hK6LvPstkj4m0NFs+DRtUbgKfYqys42ec4=
+github.com/bake/mangadex v0.0.0-20191208094511-1b8be9f2df20/go.mod h1:0EIa3RFRprO7Ey+7O0TveUY6epgxsabT82R3bkUjkzU=
+github.com/bake/mri v0.0.0-20190425192657-438a0b611ec0 h1:KwTV21ZriTZIZBdFU2g0HfPq8XYEkaMKJRS9oCbBwYY=
+github.com/bake/mri v0.0.0-20190425192657-438a0b611ec0/go.mod h1:8fakjROSAHC99lr4SIARs4xZa0pPXcWTRT4TBaqfRHI=
 github.com/bmaupin/go-epub v0.5.3 h1:HBOJS2KqsRGGcEzM470/9l5q2l9JwAUxQabEgPMrW90=
 github.com/bmaupin/go-epub v0.5.3/go.mod h1:4RBr0Zo03mRGOyGAcc25eLOqIPCkMbfz+tINVmH6clQ=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -69,8 +71,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
-github.com/schollz/progressbar v1.0.0 h1:gbyFReLHDkZo8mxy/dLWMr+Mpb1MokGJ1FqCiqacjZM=
-github.com/schollz/progressbar v1.0.0/go.mod h1:/l9I7PC3L3erOuz54ghIRKUEFcosiWfLvJv+Eq26UMs=
 github.com/schollz/progressbar/v2 v2.13.2 h1:3L9bP5KQOGEnFP8P5V8dz+U0yo5I29iY5Oa9s9EAwn0=
 github.com/schollz/progressbar/v2 v2.13.2/go.mod h1:6YZjqdthH6SCZKv2rqGryrxPtfmRB/DWZxSMfCXPyD8=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/BakeRolls/mri"
 	"github.com/Girbons/comics-downloader/pkg/util"
+	"github.com/bake/mri"
 	epub "github.com/bmaupin/go-epub"
 	"github.com/jung-kurt/gofpdf"
 	"github.com/mholt/archiver"

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -93,6 +93,5 @@ func (m *Mangadex) GetInfo(url string) (string, string) {
 func (m *Mangadex) Initialize(comic *core.Comic) error {
 	links, err := m.getLinks(comic.URLSource)
 	comic.Links = links
-
 	return err
 }

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -40,6 +40,9 @@ func (m *Mangadex) getLinks(url string) ([]string, error) {
 
 func (m *Mangadex) RetrieveIssueLinks(url string, all, last bool) ([]string, error) {
 	parts := util.TrimAndSplitURL(url)
+	if len(parts) < 5 {
+		return nil, errors.New("URL not supported")
+	}
 	switch parts[3] {
 	case "chapter":
 		return []string{url}, nil
@@ -57,6 +60,9 @@ func (m *Mangadex) RetrieveIssueLinks(url string, all, last bool) ([]string, err
 		}
 		if len(urls) == 0 {
 			return nil, errors.New("no chapters found")
+		}
+		if last {
+			urls = urls[len(urls)-1:]
 		}
 		return urls, nil
 	default:

--- a/pkg/sites/mangadex_test.go
+++ b/pkg/sites/mangadex_test.go
@@ -29,9 +29,43 @@ func TestMangadexSetup(t *testing.T) {
 
 func TestMangadexRetrieveIssueLinks(t *testing.T) {
 	md := NewMangadex("")
-
-	issues, err := md.RetrieveIssueLinks("https://mangadex.org/chapter/155061/1", false, false)
-
+	urls, err := md.RetrieveIssueLinks("https://mangadex.org/chapter/155061/", false, false)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(issues))
+	assert.Equal(t, 1, len(urls))
+}
+
+func TestMangadexRetrieveIssueLinksAllChapter(t *testing.T) {
+	md := NewMangadex("gb")
+	urls, err := md.RetrieveIssueLinks("https://mangadex.org/title/5/naruto/", true, false)
+	assert.Nil(t, err)
+	assert.Len(t, urls, 569)
+}
+
+func TestMangadexRetrieveIssueLinksLastChapter(t *testing.T) {
+	md := NewMangadex("gb")
+	urls, err := md.RetrieveIssueLinks("https://mangadex.org/title/5/naruto/", false, true)
+	assert.Nil(t, err)
+	assert.Len(t, urls, 1)
+	assert.Equal(t, "https://mangadex.org/chapter/670438", urls[0])
+}
+
+func TestMangadexUnsupportedURL(t *testing.T) {
+	md := NewMangadex("")
+	_, err := md.RetrieveIssueLinks("https://mangadex.org/", false, false)
+	assert.EqualError(t, err, "URL not supported")
+	_, err = md.RetrieveIssueLinks("https://mangadex.org/test/0/", false, false)
+	assert.EqualError(t, err, "URL not supported")
+}
+
+func TestMangadexNoManga(t *testing.T) {
+	md := NewMangadex("")
+	_, err := md.RetrieveIssueLinks("https://mangadex.org/title/0/", false, false)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Manga ID does not exist")
+}
+
+func TestMangadexNoChapters(t *testing.T) {
+	md := NewMangadex("xyz")
+	_, err := md.RetrieveIssueLinks("https://mangadex.org/title/5/naruto/", true, false)
+	assert.EqualError(t, err, "no chapters found")
 }


### PR DESCRIPTION
Hi, another change I forgot in my last PR: Adding a `-last` flag to MangaDex. The library [sorts chapters by their ID](https://github.com/bake/mangadex/commit/420dda80e3fdf675cb09570de5ba19c8d23a283b) so it's just a `if last { urls = urls[len(urls)-1:] }` to skip older chapters.