### PR TITLE
Mangadex URL fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can invoke the `--help`:
 |https://www.mangareader.net/ |&#x2713;|&#x2717;|&#x2713;|
 |http://www.mangatown.com/    |&#x2713;|&#x2717;|&#x2713;|
 |https://mangadex.cc/         |&#x2713;|&#x2713;|&#x2713;|
-
+|https://mangadex.org/        |&#x2713;|&#x2713;|&#x2713;|
 
 ### Checking for mangas using a Raspberry Pi
 

--- a/pkg/sites/base.go
+++ b/pkg/sites/base.go
@@ -9,6 +9,7 @@ var SupportedSites = []string{
 	"www.mangatown.com",
 	"www.mangahere.cc",
 	"mangadex.cc",
+	"mangadex.org",
 }
 
 // DisabledSites are the sites that are currently disabled.

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -57,8 +57,8 @@ func LoadComicFromSource(source, url, country, format, imagesFormat string, all,
 		siteSource = &Mangareader{}
 	case "www.mangatown.com":
 		siteSource = &Mangatown{}
-	case "mangadex.cc":
-		siteSource = NewMangadex(country)
+	case "mangadex.cc", "mangadex.org":
+		siteSource = NewMangadex(country, source)
 	default:
 		err = fmt.Errorf("It was not possible to determine the source")
 		return collection, err

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -11,15 +11,18 @@ import (
 
 type Mangadex struct {
 	country string
+	baseURL string
 	Client  *mangadex.Client
 }
 
 // NewMangadex returns a Mangadex instance
-func NewMangadex(country string) *Mangadex {
+func NewMangadex(country, source string) *Mangadex {
+	mangadexBase := "https://"+source+"/"
 	return &Mangadex{
 		country: country,
+		baseURL: mangadexBase,
 		Client: mangadex.New(
-			mangadex.WithBase("https://mangadex.cc/"),
+			mangadex.WithBase(mangadexBase),
 		),
 	}
 }
@@ -58,7 +61,7 @@ func (m *Mangadex) RetrieveIssueLinks(url string, all, last bool) ([]string, err
 			if m.country != "" && c.LangCode != m.country {
 				continue
 			}
-			urls = append(urls, "https://mangadex.cc/chapter"+c.ID.String())
+			urls = append(urls, m.baseURL+"chapter"+c.ID.String())
 		}
 		if len(urls) == 0 {
 			return nil, errors.New("no chapters found")

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -61,7 +61,7 @@ func (m *Mangadex) RetrieveIssueLinks(url string, all, last bool) ([]string, err
 			if m.country != "" && c.LangCode != m.country {
 				continue
 			}
-			urls = append(urls, m.baseURL+"chapter"+c.ID.String())
+			urls = append(urls, m.baseURL+"chapter/"+c.ID.String())
 		}
 		if len(urls) == 0 {
 			return nil, errors.New("no chapters found")

--- a/pkg/sites/mangadex_test.go
+++ b/pkg/sites/mangadex_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testMangadexURL string = "https://mangadex.org/"
+const testMangadexBase string = "mangadex.org"
+const testMangadexURL  string = "https://"+testMangadexBase+"/"
 
 func TestMangadexGetInfo(t *testing.T) {
-	md := NewMangadex("")
+	md := NewMangadex("", testMangadexBase)
 
 	name, issueNumber := md.GetInfo(testMangadexURL+"chapter/155061/1")
 	assert.Equal(t, "Naruto", name)
@@ -18,7 +19,7 @@ func TestMangadexGetInfo(t *testing.T) {
 }
 
 func TestMangadexSetup(t *testing.T) {
-	md := NewMangadex("")
+	md := NewMangadex("", testMangadexBase)
 	comic := new(core.Comic)
 
 	comic.URLSource = testMangadexURL+"chapter/155061/1"
@@ -30,21 +31,21 @@ func TestMangadexSetup(t *testing.T) {
 }
 
 func TestMangadexRetrieveIssueLinks(t *testing.T) {
-	md := NewMangadex("")
+	md := NewMangadex("", testMangadexBase)
 	urls, err := md.RetrieveIssueLinks(testMangadexURL+"chapter/155061/", false, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(urls))
 }
 
 func TestMangadexRetrieveIssueLinksAllChapter(t *testing.T) {
-	md := NewMangadex("gb")
+	md := NewMangadex("gb", testMangadexBase)
 	urls, err := md.RetrieveIssueLinks(testMangadexURL+"title/5/naruto/", true, false)
 	assert.Nil(t, err)
 	assert.Len(t, urls, 569)
 }
 
 func TestMangadexRetrieveIssueLinksLastChapter(t *testing.T) {
-	md := NewMangadex("gb")
+	md := NewMangadex("gb", testMangadexBase)
 	urls, err := md.RetrieveIssueLinks(testMangadexURL+"title/5/naruto/", false, true)
 	assert.Nil(t, err)
 	assert.Len(t, urls, 1)
@@ -52,7 +53,7 @@ func TestMangadexRetrieveIssueLinksLastChapter(t *testing.T) {
 }
 
 func TestMangadexUnsupportedURL(t *testing.T) {
-	md := NewMangadex("")
+	md := NewMangadex("", testMangadexBase)
 	_, err := md.RetrieveIssueLinks(testMangadexURL, false, false)
 	assert.EqualError(t, err, "URL not supported")
 	_, err = md.RetrieveIssueLinks(testMangadexURL+"test/0/", false, false)
@@ -60,14 +61,14 @@ func TestMangadexUnsupportedURL(t *testing.T) {
 }
 
 func TestMangadexNoManga(t *testing.T) {
-	md := NewMangadex("")
+	md := NewMangadex("", testMangadexBase)
 	_, err := md.RetrieveIssueLinks(testMangadexURL+"title/0/", false, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Manga ID does not exist")
 }
 
 func TestMangadexNoChapters(t *testing.T) {
-	md := NewMangadex("xyz")
+	md := NewMangadex("xyz", testMangadexBase)
 	_, err := md.RetrieveIssueLinks(testMangadexURL+"title/5/naruto/", true, false)
 	assert.EqualError(t, err, "no chapters found")
 }

--- a/pkg/sites/mangadex_test.go
+++ b/pkg/sites/mangadex_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const testMangadexURL string = "https://mangadex.org/"
+
 func TestMangadexGetInfo(t *testing.T) {
 	md := NewMangadex("")
 
-	name, issueNumber := md.GetInfo("https://mangadex.cc/chapter/155061/1")
+	name, issueNumber := md.GetInfo(testMangadexURL+"chapter/155061/1")
 	assert.Equal(t, "Naruto", name)
 	assert.Equal(t, "Vol 60 Chapter 575, A Will of Stone", issueNumber)
 }
@@ -19,7 +21,7 @@ func TestMangadexSetup(t *testing.T) {
 	md := NewMangadex("")
 	comic := new(core.Comic)
 
-	comic.URLSource = "https://mangadex.cc/chapter/155061/1"
+	comic.URLSource = testMangadexURL+"chapter/155061/1"
 
 	err := md.Initialize(comic)
 
@@ -29,43 +31,43 @@ func TestMangadexSetup(t *testing.T) {
 
 func TestMangadexRetrieveIssueLinks(t *testing.T) {
 	md := NewMangadex("")
-	urls, err := md.RetrieveIssueLinks("https://mangadex.cc/chapter/155061/", false, false)
+	urls, err := md.RetrieveIssueLinks(testMangadexURL+"chapter/155061/", false, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(urls))
 }
 
 func TestMangadexRetrieveIssueLinksAllChapter(t *testing.T) {
 	md := NewMangadex("gb")
-	urls, err := md.RetrieveIssueLinks("https://mangadex.cc/title/5/naruto/", true, false)
+	urls, err := md.RetrieveIssueLinks(testMangadexURL+"title/5/naruto/", true, false)
 	assert.Nil(t, err)
 	assert.Len(t, urls, 569)
 }
 
 func TestMangadexRetrieveIssueLinksLastChapter(t *testing.T) {
 	md := NewMangadex("gb")
-	urls, err := md.RetrieveIssueLinks("https://mangadex.cc/title/5/naruto/", false, true)
+	urls, err := md.RetrieveIssueLinks(testMangadexURL+"title/5/naruto/", false, true)
 	assert.Nil(t, err)
 	assert.Len(t, urls, 1)
-	assert.Equal(t, "https://mangadex.cc/chapter670438", urls[0])
+	assert.Equal(t, testMangadexURL+"chapter/670438", urls[0])
 }
 
 func TestMangadexUnsupportedURL(t *testing.T) {
 	md := NewMangadex("")
-	_, err := md.RetrieveIssueLinks("https://mangadex.cc/", false, false)
+	_, err := md.RetrieveIssueLinks(testMangadexURL, false, false)
 	assert.EqualError(t, err, "URL not supported")
-	_, err = md.RetrieveIssueLinks("https://mangadex.cc/test/0/", false, false)
+	_, err = md.RetrieveIssueLinks(testMangadexURL+"test/0/", false, false)
 	assert.EqualError(t, err, "URL not supported")
 }
 
 func TestMangadexNoManga(t *testing.T) {
 	md := NewMangadex("")
-	_, err := md.RetrieveIssueLinks("https://mangadex.cc/title/0/", false, false)
+	_, err := md.RetrieveIssueLinks(testMangadexURL+"title/0/", false, false)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Manga ID does not exist")
 }
 
 func TestMangadexNoChapters(t *testing.T) {
 	md := NewMangadex("xyz")
-	_, err := md.RetrieveIssueLinks("https://mangadex.cc/title/5/naruto/", true, false)
+	_, err := md.RetrieveIssueLinks(testMangadexURL+"title/5/naruto/", true, false)
 	assert.EqualError(t, err, "no chapters found")
 }


### PR DESCRIPTION
This PR addresses #48, which states that Mangadex recently reverted back to a `.org` domain. In order to protect against this issue in the future, I have decided to add support for both `mangadex.cc` and `mangadex.org`. I didn't bother to implement any tests for `mangadex.cc` as it doesn't seem to be usable at all a the current moment

#### **`go test -v ./...` results**
```
?       github.com/Girbons/comics-downloader/cmd/app    [no test files]
?       github.com/Girbons/comics-downloader/cmd/downloader     [no test files]
?       github.com/Girbons/comics-downloader/cmd/gui    [no test files]
?       github.com/Girbons/comics-downloader/internal/version   [no test files]
=== RUN   TestNewComic
--- PASS: TestNewComic (0.00s)
=== RUN   TestMakeComicPDF
 100% |████████████████████████████████████████|  [0s:0s]time="2020-01-16T17:47:22-05:00" level=info msg="PDF file correctly saved"
--- PASS: TestMakeComicPDF (0.28s)
=== RUN   TestMakeComicEPUB
 100% |████████████████████████████████████████|  [0s:0s]time="2020-01-16T17:47:22-05:00" level=info msg="EPUB file correctly saved"
--- PASS: TestMakeComicEPUB (0.22s)
=== RUN   TestDownloadImagesPNGFormat
 100% |████████████████████████████████████████|  [0s:0s]--- PASS: TestDownloadImagesPNGFormat (0.21s)
=== RUN   TestDownloadImagesJPGFormat
 100% |████████████████████████████████████████|  [0s:0s]--- PASS: TestDownloadImagesJPGFormat (0.17s)
=== RUN   TestDownloadImagesJPEGFormat
 100% |████████████████████████████████████████|  [0s:0s]--- PASS: TestDownloadImagesJPEGFormat (0.17s)
=== RUN   TestDownloadImagesIMGFormat
 100% |████████████████████████████████████████|  [0s:0s]--- PASS: TestDownloadImagesIMGFormat (0.15s)
PASS
ok      github.com/Girbons/comics-downloader/pkg/core   1.576s
=== RUN   TestDetectComicExtra
--- PASS: TestDetectComicExtra (0.00s)
=== RUN   TestUnsupportedSource
--- PASS: TestUnsupportedSource (0.00s)
PASS
ok      github.com/Girbons/comics-downloader/pkg/detector       (cached)
=== RUN   TestSiteLoaderMangatown
--- PASS: TestSiteLoaderMangatown (15.19s)
=== RUN   TestSiteLoaderMangareader
--- PASS: TestSiteLoaderMangareader (4.77s)
=== RUN   TestLoaderUnknownSource
--- PASS: TestLoaderUnknownSource (0.00s)
=== RUN   TestMangadexGetInfo
--- PASS: TestMangadexGetInfo (1.73s)
=== RUN   TestMangadexSetup
--- PASS: TestMangadexSetup (0.25s)
=== RUN   TestMangadexRetrieveIssueLinks
--- PASS: TestMangadexRetrieveIssueLinks (0.00s)
=== RUN   TestMangadexRetrieveIssueLinksAllChapter
--- PASS: TestMangadexRetrieveIssueLinksAllChapter (1.19s)
=== RUN   TestMangadexRetrieveIssueLinksLastChapter
--- PASS: TestMangadexRetrieveIssueLinksLastChapter (0.97s)
=== RUN   TestMangadexUnsupportedURL
--- PASS: TestMangadexUnsupportedURL (0.00s)
=== RUN   TestMangadexNoManga
--- PASS: TestMangadexNoManga (0.26s)
=== RUN   TestMangadexNoChapters
--- PASS: TestMangadexNoChapters (1.02s)
=== RUN   TestMangaReadGetInfo
--- PASS: TestMangaReadGetInfo (0.00s)
=== RUN   TestRetrieveMangaReaderImageLinks
--- PASS: TestRetrieveMangaReaderImageLinks (9.08s)
=== RUN   TestSetupMangaReader
--- PASS: TestSetupMangaReader (8.30s)
=== RUN   TestMangareaderRetrieveIssueLinks
--- PASS: TestMangareaderRetrieveIssueLinks (0.28s)
=== RUN   TestMangareaderRetrieveIssueLinksLast
--- PASS: TestMangareaderRetrieveIssueLinksLast (0.16s)
=== RUN   TestMangaReaderRetrieveLastIssueLink
--- PASS: TestMangaReaderRetrieveLastIssueLink (0.28s)
=== RUN   TestMangatownGetInfo
--- PASS: TestMangatownGetInfo (0.00s)
=== RUN   TestMangatownSetup
--- PASS: TestMangatownSetup (14.03s)
=== RUN   TestMangatownRetrieveIssueLinks
--- PASS: TestMangatownRetrieveIssueLinks (0.46s)
=== RUN   TestMangatownRetrieveIssueLinksLastChapter
--- PASS: TestMangatownRetrieveIssueLinksLastChapter (0.55s)
=== RUN   TestMangatownRetrieveLastIssueLink
--- PASS: TestMangatownRetrieveLastIssueLink (0.32s)
PASS
ok      github.com/Girbons/comics-downloader/pkg/sites  59.877s
=== RUN   TestTrimAndSplitURL
--- PASS: TestTrimAndSplitURL (0.00s)
=== RUN   TestUrlSource
--- PASS: TestUrlSource (0.00s)
=== RUN   TestIsValueInSlice
--- PASS: TestIsValueInSlice (0.00s)
=== RUN   TestIsUrlValid
--- PASS: TestIsUrlValid (0.00s)
=== RUN   TestImageType
--- PASS: TestImageType (0.00s)
=== RUN   TestConvertImage
--- PASS: TestConvertImage (1.57s)
=== RUN   TestPathSetup
--- PASS: TestPathSetup (0.00s)
=== RUN   TestParse
--- PASS: TestParse (0.00s)
=== RUN   TestGenerateFileName
--- PASS: TestGenerateFileName (0.00s)
=== RUN   TestDirectoryOrFileDoesNotExist
--- PASS: TestDirectoryOrFileDoesNotExist (0.00s)
PASS
ok      github.com/Girbons/comics-downloader/pkg/util   (cached)
```