### PR TITLE
Add Mangadex Country Code Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ You can invoke the `--help`:
   -all
         Download all issues of the Comic or Comics
   -country string
-        Set the country to retrieve a manga, Used by MangaRock and MangaDex
+        Set the country to retrieve a manga, Used by MangaRock and MangaDex. For MangaDex, ISO 3166-1 codes are 
+        used for the country flag. a full list of codes MangaDex uses can be found at
+        https://github.com/md-y/mangadex-full-api/blob/master/src/enum/language.js on the left side.
+        Make sure the country code is lowercase before adding it as a flag
   -daemon
         Run the download as daemon
   -format string


### PR DESCRIPTION
Adds information regarding the language code standard Mangadex uses for their API. #50 should be closed as the issue is fixed by providing more information through this PR.