### PR TITLE
Add newline to -version flag output

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -53,7 +53,7 @@ func main() {
 	flag.Parse()
 
 	if versionFlag {
-		fmt.Printf("comics-downloader version %s", version.Tag, "\n")
+		fmt.Printf("comics-downloader version", version.Tag)
 		os.Exit(0)
 	}
 

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -53,7 +53,7 @@ func main() {
 	flag.Parse()
 
 	if versionFlag {
-		fmt.Printf("comics-downloader version %s", version.Tag)
+		fmt.Printf("comics-downloader version %s", version.Tag, "\n")
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
This pull request fixes an issue that was introduced in https://github.com/Girbons/comics-downloader/commit/0153a53b6bbcd5597a1d831d7638f1723af0e3e1#diff-8b49c8613a458a847d25c5202e9d22a8L35 by appending a newline to the end of the `-version` flag output.

The output when running the latest version of `comics-downloader` with the `-version` flag is
```
whalehub@pdh:~# comics-downloader -version
comics-downloader version v0.22.3whalehub@pdh:~#
```
but it should be
```
whalehub@pdh:~# comics-downloader -version
comics-downloader version v0.22.3
whalehub@pdh:~#
```
