### PR TITLE
Add support for readcomiconline.to

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ## Supported Sites
 
 - https://www.comicextra.com/
+- https://readcomiconline.to/
 - https://www.mangareader.net/
 - https://www.mangatown.com/
 - https://mangadex.cc/
@@ -73,6 +74,7 @@ Usage:
 | Source                      | all    | country| last   |
 |-----------------------------|--------|--------|--------|
 |http://www.comicextra.com/   |&#x2713;|&#x2717;|&#x2713;|
+|https://readcomiconline.to/  |&#x2713;|&#x2717;|&#x2713;|
 |https://www.mangareader.net/ |&#x2713;|&#x2717;|&#x2713;|
 |http://www.mangatown.com/    |&#x2713;|&#x2717;|&#x2713;|
 |https://mangadex.cc/         |&#x2713;|&#x2713;|&#x2713;|

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -8,6 +8,7 @@ import (
 // SupportedSites are the supported sites.
 var SupportedSites = map[string]map[string]bool{
 	"www.comicextra.com":  {"isDisabled": false},
+	"readcomiconline.to":  {"isDisabled": false},
 	"www.mangareader.net": {"isDisabled": false},
 	"www.mangatown.com":   {"isDisabled": false},
 	"www.mangahere.cc":    {"isDisabled": false},

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -54,6 +54,8 @@ func LoadComicFromSource(options *config.Options) ([]*core.Comic, error) {
 	)
 
 	switch options.Source {
+	case "readcomiconline.to":
+		base = &ReadComicOnline{}
 	case "www.comicextra.com":
 		base = &Comicextra{}
 	case "www.mangareader.net":

--- a/pkg/sites/readcomiconline.go
+++ b/pkg/sites/readcomiconline.go
@@ -1,0 +1,114 @@
+package sites
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Girbons/comics-downloader/pkg/core"
+	"github.com/Girbons/comics-downloader/pkg/util"
+	"github.com/anaskhan96/soup"
+)
+
+type ReadComicOnline struct{}
+
+func (c *ReadComicOnline) retrieveImageLinks(comic *core.Comic) ([]string, error) {
+	var links []string
+
+	comic.URLSource = strings.Split(comic.URLSource, "?")[0]
+
+	response, err := soup.Get(comic.URLSource + "?quality=hd&readType=1")
+	if err != nil {
+		return nil, err
+	}
+
+	re := regexp.MustCompile(`push\(\"(.*?)\"\)`)
+	match := re.FindAllStringSubmatch(response, -1)
+
+	for i := range match {
+		url := match[i][1]
+		if util.IsURLValid(url) {
+			links = append(links, url)
+		}
+	}
+
+	return links, err
+}
+
+func (c *ReadComicOnline) isSingleIssue(url string) bool {
+	parts := util.TrimAndSplitURL(url)
+	return len(parts) > 5 && strings.Contains(parts[5], "Issue-")
+}
+
+func (c *ReadComicOnline) retrieveLastIssue(url string) (string, error) {
+	var lastIssue string
+
+	response, err := soup.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	name := util.TrimAndSplitURL(url)[4]
+	re := regexp.MustCompile("<a[^>]+href=\"([^\">]+" + "/" + name + "/.+)\"")
+	match := re.FindAllStringSubmatch(response, -1)
+	lastIssue = "https://readcomiconline.to" + strings.Split(match[0][1], "?")[0]
+
+	return lastIssue, nil
+}
+
+// RetrieveIssueLinks gets a slice of urls for all issues in a comic
+func (c *ReadComicOnline) RetrieveIssueLinks(url string, all, last bool) ([]string, error) {
+	if last {
+		issue, err := c.retrieveLastIssue(url)
+		return []string{issue}, err
+	}
+
+	if all && c.isSingleIssue(url) {
+		url = "https://readcomiconline.to/Comic/" + util.TrimAndSplitURL(url)[3]
+	} else if c.isSingleIssue(url) {
+		return []string{url}, nil
+	}
+
+	name := util.TrimAndSplitURL(url)[4]
+	var (
+		pages []string
+		links []string
+	)
+
+	response, err := soup.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	pages = append(pages, url)
+	re := regexp.MustCompile("<a[^>]+href=\"([^\">]+" + "/" + name + "/.+)\"")
+	match := re.FindAllStringSubmatch(response, -1)
+
+	for i := range match {
+		url := match[i][1]
+		if !util.IsValueInSlice(url, pages) {
+			url = "https://readcomiconline.to" + strings.Split(url, "?")[0]
+			if util.IsURLValid(url) && !util.IsValueInSlice(url, links) {
+				links = append(links, url)
+			}
+		}
+	}
+
+	return links, err
+}
+
+func (c *ReadComicOnline) GetInfo(url string) (string, string) {
+	parts := util.TrimAndSplitURL(url)
+	name := parts[4]
+	issueNumber := strings.Split(strings.Replace(parts[5], "Issue-", "", -1), "?")[0]
+
+	return name, issueNumber
+}
+
+// Initialize will initialize the comic based
+// on ReadComicOnline.to
+func (c *ReadComicOnline) Initialize(comic *core.Comic) error {
+	links, err := c.retrieveImageLinks(comic)
+	comic.Links = links
+
+	return err
+}

--- a/pkg/sites/readcomiconline_test.go
+++ b/pkg/sites/readcomiconline_test.go
@@ -1,0 +1,51 @@
+package sites
+
+import (
+	"testing"
+
+	"github.com/Girbons/comics-downloader/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadComicOnlineSetup(t *testing.T) {
+	comic := new(core.Comic)
+	comic.URLSource = "https://readcomiconline.to/Comic/Batman-2016/Issue-58?id=143175"
+
+	readComicOnline := new(ReadComicOnline)
+	err := readComicOnline.Initialize(comic)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 24, len(comic.Links))
+}
+
+func TestReadComicOnlineGetInfo(t *testing.T) {
+	readComicOnline := new(ReadComicOnline)
+	name, issueNumber := readComicOnline.GetInfo("https://readcomiconline.to/Comic/Batman-2016/Issue-58?id=143175")
+
+	assert.Equal(t, "Batman-2016", name)
+	assert.Equal(t, "58", issueNumber)
+}
+
+func TestReadComicOnlineRetrieveIssueLinks(t *testing.T) {
+	readComicOnline := new(ReadComicOnline)
+	issues, err := readComicOnline.RetrieveIssueLinks("https://readcomiconline.to/Comic/100-Bullets", false, false)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 100, len(issues))
+}
+
+func TestReadComicOnlineRetrieveIssueLinksLastChapter(t *testing.T) {
+	readComicOnline := new(ReadComicOnline)
+	issues, err := readComicOnline.RetrieveIssueLinks("https://readcomiconline.to/Comic/100-Bullets", false, true)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(issues))
+}
+
+func TestReadComicOnlineRetrieveLastIssueLink(t *testing.T) {
+	readComicOnline := new(ReadComicOnline)
+	issue, err := readComicOnline.retrieveLastIssue("https://readcomiconline.to/Comic/100-Bullets")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "https://readcomiconline.to/Comic/100-Bullets/Issue-100-2", issue)
+}


### PR DESCRIPTION
Thank you for open-sourcing this project @Girbons! 

This PR add support for a new Comic website: https://readcomiconline.to

I found that readcomiconline.to is more reliable especially for older comics, sometimes comicextra.com chapters are missing some images.

