### PR TITLE
Grab image size, use to set PDF page size

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -22,7 +22,8 @@ var (
 	// manga/comic language
 	country string
 	// manga/comic final output
-	format string
+	forceAspect bool
+	format      string
 	// url source
 	url string
 	// folder where the files will be saved
@@ -45,6 +46,7 @@ func init() {
 	flag.BoolVar(&versionFlag, "version", false, "Display release version")
 
 	flag.StringVar(&country, "country", "", "Set the country to retrieve a manga, Used by MangaDex which uses ISO 3166-1 codes")
+	flag.BoolVar(&forceAspect, "force-aspect", false, "Force images to A4 Portrait aspect ratio")
 	flag.StringVar(&format, "format", "pdf", "Comic format output, supported formats are pdf,epub,cbr,cbz")
 	flag.StringVar(&imagesFormat, "images-format", "jpg", "To use with `images-only` flag, choose the image format, available png,jpeg,img")
 	flag.StringVar(&url, "url", "", "Comic URL or Comic URLS by separating each site with a comma without the use of spaces")
@@ -70,6 +72,7 @@ func main() {
 		ImagesOnly:   imagesOnly,
 		ImagesFormat: imagesFormat,
 		URL:          url,
+		ForceAspect:  forceAspect,
 		Format:       format,
 		Daemon:       daemon,
 		Timeout:      timeout,

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -12,6 +12,7 @@ type Options struct {
 	ImagesFormat string
 	Country      string
 	Format       string
+	ForceAspect  bool
 	OutputFolder string
 	URL          string
 	Source       string

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -145,10 +145,10 @@ func (comic *Comic) makePDF(options *config.Options) error {
 				im, _, err := image.DecodeConfig(img)
 				if err != nil {
 					options.Logger.Error(err.Error())
-					continue
+				} else {
+					mmWd = px2mm*float64(im.Width)
+					mmHt = px2mm*float64(im.Height)
 				}
-				mmWd = px2mm*float64(im.Width)
-				mmHt = px2mm*float64(im.Height)
 				img.Close()
 			} else {
 				options.Logger.Error(err.Error())

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"image"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -115,6 +116,8 @@ func (comic *Comic) makeEPUB(options *config.Options) error {
 // makePDF create the pdf file
 func (comic *Comic) makePDF(options *config.Options) error {
 	var err error
+	var mmWd, mmHt float64
+	const px2mm = 0.2645833333
 
 	pdf := gofpdf.New("P", "mm", "A4", "")
 
@@ -130,17 +133,33 @@ func (comic *Comic) makePDF(options *config.Options) error {
 		return err
 	}
 
+	imageOptions := gofpdf.ImageOptions{ImageType: util.ImageType(comic.ImagesFormat), ReadDpi: true, AllowNegativePosition: false}
 	for _, file := range files {
-		pdf.AddPage()
-		imageOptions := gofpdf.ImageOptions{ImageType: util.ImageType(comic.ImagesFormat), ReadDpi: true, AllowNegativePosition: false}
-		fileName := fmt.Sprintf("%s/%s", imagesPath, file.Name())
+		mmWd = 210.0
+		mmHt = 297.0
+		fileName := fmt.Sprintf("%s%s%s", imagesPath, string(os.PathSeparator), file.Name())
+
+		img, err := os.Open(fileName)
+		if err == nil {
+			im, _, err := image.DecodeConfig(img)
+			if err != nil {
+				// DEBUG MESSAGE
+				// fmt.Fprintf(os.Stderr, "%s: %v\n", fileName, err)
+				continue
+			}
+			mmWd = px2mm*float64(im.Width)
+			mmHt = px2mm*float64(im.Height)
+			img.Close()
+		}
+		pdf.AddPageFormat("P", gofpdf.SizeType{Wd: mmWd, Ht: mmHt})
+
 		data, err := ioutil.ReadFile(fileName)
 		if err != nil {
 			return err
 		}
 		content := bytes.NewReader(data)
 		pdf.RegisterImageOptionsReader(file.Name(), imageOptions, content)
-		pdf.Image(file.Name(), 0, 0, 210, 297, false, comic.ImagesFormat, 0, "")
+		pdf.ImageOptions(file.Name(), 0, 0, mmWd, mmHt, false, imageOptions, 0, "")
 	}
 
 	dir, err := util.PathSetup(options.OutputFolder, comic.Source, comic.Name)

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -141,17 +141,18 @@ func (comic *Comic) makePDF(options *config.Options) error {
 
 		if !options.ForceAspect {
 			img, err := os.Open(fileName)
-			if err == nil {
-				im, _, err := image.DecodeConfig(img)
-				if err != nil {
-					options.Logger.Error(err.Error())
-				} else {
-					mmWd = px2mm*float64(im.Width)
-					mmHt = px2mm*float64(im.Height)
-				}
-				img.Close()
-			} else {
+
+			defer img.Close()
+
+			if err != nil {
 				options.Logger.Error(err.Error())
+			}
+			im, _, err := image.DecodeConfig(img)
+			if err != nil {
+				options.Logger.Error(err.Error())
+			} else {
+				mmWd = px2mm*float64(im.Width)
+				mmHt = px2mm*float64(im.Height)
 			}
 		}
 		pdf.AddPageFormat("P", gofpdf.SizeType{Wd: mmWd, Ht: mmHt})

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -139,17 +139,20 @@ func (comic *Comic) makePDF(options *config.Options) error {
 		mmHt = 297.0
 		fileName := fmt.Sprintf("%s%s%s", imagesPath, string(os.PathSeparator), file.Name())
 
-		img, err := os.Open(fileName)
-		if err == nil {
-			im, _, err := image.DecodeConfig(img)
-			if err != nil {
-				// DEBUG MESSAGE
-				// fmt.Fprintf(os.Stderr, "%s: %v\n", fileName, err)
-				continue
+		if !options.ForceAspect {
+			img, err := os.Open(fileName)
+			if err == nil {
+				im, _, err := image.DecodeConfig(img)
+				if err != nil {
+					options.Logger.Error(err.Error())
+					continue
+				}
+				mmWd = px2mm*float64(im.Width)
+				mmHt = px2mm*float64(im.Height)
+				img.Close()
+			} else {
+				options.Logger.Error(err.Error())
 			}
-			mmWd = px2mm*float64(im.Width)
-			mmHt = px2mm*float64(im.Height)
-			img.Close()
 		}
 		pdf.AddPageFormat("P", gofpdf.SizeType{Wd: mmWd, Ht: mmHt})
 


### PR DESCRIPTION
Hey, so this change opens each image, determines image size in pixels, then uses that info (based on a pixel/mm scaling) to size each individual PDF page to the image.

I haven't see it "fail", i.e. I haven't checked what goes wrong when I reach the '// DEBUG MESSAGE' part of the code, it was able to always process the image and get the info from it, but I can keep trying.

This change yields PDFs that contain unscaled images... so if the original image is more of a landscape (wider than taller) image, it remains that way in the PDF.

I suppose an option could be added, something like "-force-aspect" that would make it keep the A4 aspect ratio...

I will post a comparison of the 0.28.2 result and the result from this shortly.