### PR TITLE
Add issue-number-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Usage:
         To use with images-only flag, choose the image format, available png,jpeg,img (default "jpg")
   -images-only
         Download comic/manga images
+  -issue-number-only
+        Force only saving with issue number instead of chapter name + issue number.
   -last
         Download the last Comic issue
   -output string

--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -24,6 +24,8 @@ var (
 	// manga/comic final output
 	forceAspect bool
 	format      string
+	// force only issue number filenames
+	issueNumberNameOnly bool
 	// url source
 	url string
 	// folder where the files will be saved
@@ -51,6 +53,7 @@ func init() {
 	flag.BoolVar(&forceAspect, "force-aspect", false, "Force images to A4 Portrait aspect ratio")
 	flag.StringVar(&format, "format", "pdf", "Comic format output, supported formats are pdf,epub,cbr,cbz")
 	flag.StringVar(&imagesFormat, "images-format", "jpg", "To use with `images-only` flag, choose the image format, available png,jpeg,img")
+	flag.BoolVar(&issueNumberNameOnly, "issue-number-only", false, "Force only saving with issue number instead of chapter name + issue number.")
 	flag.StringVar(&url, "url", "", "Comic URL or Comic URLS by separating each site with a comma without the use of spaces")
 	flag.StringVar(&outputFolder, "output", "", "Folder where the comics will be saved")
 	flag.StringVar(&issuesRange, "range", "", "Range of issues to download, example 3-9")
@@ -67,20 +70,21 @@ func main() {
 	}
 
 	options := &config.Options{
-		Debug:             debug,
-		All:               all,
-		Last:              last,
-		Country:           country,
-		ImagesOnly:        imagesOnly,
-		ImagesFormat:      imagesFormat,
-		URL:               url,
-		ForceAspect:       forceAspect,
-		Format:            format,
-		Daemon:            daemon,
-		Timeout:           timeout,
-		OutputFolder:      outputFolder,
-		CreateDefaultPath: createDefaultPath,
-		IssuesRange:       issuesRange,
+		Debug:               debug,
+		All:                 all,
+		Last:                last,
+		Country:             country,
+		ImagesOnly:          imagesOnly,
+		ImagesFormat:        imagesFormat,
+		IssueNumberNameOnly: issueNumberNameOnly,
+		URL:                 url,
+		ForceAspect:         forceAspect,
+		Format:              format,
+		Daemon:              daemon,
+		Timeout:             timeout,
+		OutputFolder:        outputFolder,
+		CreateDefaultPath:   createDefaultPath,
+		IssuesRange:         issuesRange,
 	}
 
 	app.Run(options)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -4,21 +4,22 @@ import "github.com/Girbons/comics-downloader/internal/logger"
 
 // Options represents the comics downloader options.
 type Options struct {
-	Debug             bool
-	All               bool
-	Last              bool
-	ImagesOnly        bool
-	Daemon            bool
-	ImagesFormat      string
-	Country           string
-	Format            string
-	ForceAspect       bool
-	OutputFolder      string
-	CreateDefaultPath bool
-	URL               string
-	Source            string
-	IssuesRange       string
-	Timeout           int
+	Debug               bool
+	All                 bool
+	Last                bool
+	ImagesOnly          bool
+	Daemon              bool
+	ImagesFormat        string
+	Country             string
+	Format              string
+	ForceAspect         bool
+	OutputFolder        string
+	CreateDefaultPath   bool
+	IssueNumberNameOnly bool
+	URL                 string
+	Source              string
+	IssuesRange         string
+	Timeout             int
 
 	Logger *logger.Logger
 }

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -105,7 +105,7 @@ func (comic *Comic) makeEPUB(options *config.Options) error {
 		return err
 	}
 
-	if err = e.Write(util.GetPathToFile(dir, comic.Name, comic.IssueNumber, comic.Format)); err != nil {
+	if err = e.Write(util.GetPathToFile(dir, comic.Name, comic.IssueNumber, comic.Format, options.IssueNumberNameOnly)); err != nil {
 		return err
 	}
 
@@ -173,7 +173,7 @@ func (comic *Comic) makePDF(options *config.Options) error {
 	}
 
 	// Save the pdf file
-	filePath := util.GetPathToFile(dir, comic.Name, comic.IssueNumber, comic.Format)
+	filePath := util.GetPathToFile(dir, comic.Name, comic.IssueNumber, comic.Format, options.IssueNumberNameOnly)
 	if err = pdf.OutputFileAndClose(filePath); err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (comic *Comic) makeCBRZ(options *config.Options) error {
 	}
 	// the archive must be created as `.zip`then change the extension to `.cbr`or `.cbz`.
 	zipArchiveName := fmt.Sprintf("%s/%s.zip", dir, comic.IssueNumber)
-	newName := util.GetPathToFile(dir, comic.Name, comic.IssueNumber, comic.Format)
+	newName := util.GetPathToFile(dir, comic.Name, comic.IssueNumber, comic.Format, options.IssueNumberNameOnly)
 
 	if err = archive.Archive(filesToAdd, zipArchiveName); err != nil {
 		return err

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -40,7 +40,7 @@ func initializeCollection(issues []string, options *config.Options, base BaseSit
 		}
 
 		dir, _ := util.PathSetup(options.CreateDefaultPath, options.OutputFolder, options.Source, name)
-		fileName := util.GetPathToFile(dir, name, issueNumber, options.Format)
+		fileName := util.GetPathToFile(dir, name, issueNumber, options.Format, options.IssueNumberNameOnly)
 
 		if util.DirectoryOrFileDoesNotExist(fileName) || options.ImagesOnly {
 			comic := &core.Comic{

--- a/pkg/util/path.go
+++ b/pkg/util/path.go
@@ -62,6 +62,9 @@ func DirectoryOrFileDoesNotExist(filePath string) bool {
 }
 
 // GetPathToFile returns the path where the file should be saved.
-func GetPathToFile(dir, name, issueNumber, format string) string {
+func GetPathToFile(dir, name, issueNumber, format string, issueNumberOnly bool) string {
+	if issueNumberOnly {
+		return fmt.Sprintf("%s/%s.%s", dir, issueNumber, format)
+	}
 	return fmt.Sprintf("%s/%s-%s.%s", dir, name, issueNumber, format)
 }

--- a/pkg/util/path_test.go
+++ b/pkg/util/path_test.go
@@ -17,9 +17,10 @@ func TestPathSetup(t *testing.T) {
 }
 
 func TestGenerateFileName(t *testing.T) {
-	result := GetPathToFile("path/to/something", "comic-name", "invalid_character", "pdf")
-
+	result := GetPathToFile("path/to/something", "comic-name", "invalid_character", "pdf", false)
 	assert.Equal(t, "path/to/something/comic-name-invalid_character.pdf", result)
+	result = GetPathToFile("path/to/something", "comic-name", "invalid_character", "pdf", true)
+	assert.Equal(t, "path/to/something/invalid_character.pdf", result)
 }
 
 func TestDirectoryOrFileDoesNotExist(t *testing.T) {


### PR DESCRIPTION
Adds an option to save as issue number only instead of chapter name + issue number, e.g. `2.cbz` instead of `A Case-2.cbz`