### PR TITLE
Re-enable and upgrade MangaDex

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Usage:
 | http://readallcomics.com    | &#x2713; | &#x2717; | &#x2713; |
 | http://www.comicextra.com/  | &#x2713; | &#x2717; | &#x2713; |
 | http://www.mangatown.com/   | &#x2713; | &#x2717; | &#x2713; |
-| https://mangadex.org/       | &#x2713; | &#x2713; | &#x2713; |
+| https://mangadex.org/       | &#x2713; | &#x2713; | &#x2717; |
 | https://readcomiconline.li/ | &#x2713; | &#x2717; | &#x2713; |
 | https://www.mangareader.tv/ | &#x2713; | &#x2717; | &#x2713; |
 | https://www.mangakalot.com/ | &#x2713; | &#x2717; | &#x2713; |

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.17
 require (
 	fyne.io/fyne v1.4.3
 	github.com/anaskhan96/soup v1.2.4
-	github.com/bake/mangadex/v2 v2.0.0
 	github.com/bmaupin/go-epub v0.7.2
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0
 	github.com/dsnet/compress v0.0.1 // indirect
+	github.com/frankban/quicktest v1.13.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/fyne-io/mobile v0.1.2 // indirect
 	github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7 // indirect
@@ -25,7 +25,6 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/nwaples/rardecode v1.1.2 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/schollz/progressbar/v2 v2.15.0
 	github.com/sirupsen/logrus v1.8.1
@@ -41,5 +40,4 @@ require (
 	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
-	github.com/frankban/quicktest v1.13.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,6 @@ github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9/go.mod 
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/anaskhan96/soup v1.2.4 h1:or+sKs9QbzJGZVTYFmTs2VBateEywoq00a6K14z331E=
 github.com/anaskhan96/soup v1.2.4/go.mod h1:6YnEp9A2yywlYdM4EgDz9NEHclocMepEtku7wg6Cq3s=
-github.com/bake/httpcache v0.0.0-20190425194625-775d0adac809 h1:+WthOY6+9RdivM1SPr5KRregzgSYmu++u0uphYgmoyk=
-github.com/bake/httpcache v0.0.0-20190425194625-775d0adac809/go.mod h1:4NG8FC+Gt0aSRAFe+GcCsKUGCL63u0doQyQBQffWX90=
-github.com/bake/mangadex/v2 v2.0.0 h1:6aU3XV71dMb9/9p7LRphaZ1S59EahGPz7KtvOUQ1xxM=
-github.com/bake/mangadex/v2 v2.0.0/go.mod h1:JN28yu8vFMt47EXOmHMY6QkSNjGLhczT0PHT1Fb5iWg=
 github.com/bmaupin/go-epub v0.7.2 h1:OoAVPj1EDQRp5ij4FkFIRhl0D+zi6jX9FYdjPL9gKVg=
 github.com/bmaupin/go-epub v0.7.2/go.mod h1:4RBr0Zo03mRGOyGAcc25eLOqIPCkMbfz+tINVmH6clQ=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
@@ -38,8 +34,6 @@ github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff h1:W71vTCKoxtdXgnm1E
 github.com/goki/freetype v0.0.0-20181231101311-fa8a33aabaff/go.mod h1:wfqRWLHRBsRgkp5dmbG56SA0DmVtwrF5N3oPdI8t+Aw=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
-github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
@@ -70,14 +64,11 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nwaples/rardecode v1.1.2 h1:Cj0yZY6T1Zx1R7AhTbyGSALm44/Mmq+BAPc4B/p/d3M=
 github.com/nwaples/rardecode v1.1.2/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
-github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phpdave11/gofpdi v1.0.7/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/detector/detector.go
+++ b/pkg/detector/detector.go
@@ -7,7 +7,7 @@ import (
 
 // SupportedSites are the supported sites.
 var SupportedSites = map[string]map[string]bool{
-	"mangadex.org":       {"isDisabled": true},
+	"mangadex.org":       {"isDisabled": false},
 	"mangareader.tv":     {"isDisabled": true},
 	"readallcomics.com":  {"isDisabled": false},
 	"readcomiconline.li": {"isDisabled": false},

--- a/pkg/sites/mangadex.go
+++ b/pkg/sites/mangadex.go
@@ -1,60 +1,145 @@
 package sites
 
 import (
-	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
+	"net/http"
 	"strings"
 
 	"github.com/Girbons/comics-downloader/pkg/config"
 	"github.com/Girbons/comics-downloader/pkg/core"
 	"github.com/Girbons/comics-downloader/pkg/util"
-	"github.com/bake/mangadex/v2"
 )
 
 // Mangadex represents a mangadex instance.
 type Mangadex struct {
 	country string
 	baseURL string
-	Client  *mangadex.Client
 	options *config.Options
 }
 
 // NewMangadex returns a Mangadex instance
 func NewMangadex(options *config.Options) *Mangadex {
-	mangadexBase := "https://" + options.Source + "/"
 	return &Mangadex{
 		country: strings.ToLower(options.Country),
-		baseURL: mangadexBase,
 		options: options,
-		Client: mangadex.New(
-			mangadex.WithBase(mangadexBase),
-		),
 	}
 }
 
-func (m *Mangadex) getLinks(url string) ([]string, error) {
-	var links []string
+func (m *Mangadex) getManga(mangaID string) (title string, err error) {
+	url := fmt.Sprintf("https://api.mangadex.org/manga/%s", mangaID)
+	res, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	var mangaRes struct {
+		Result string `json:"result"`
+		Data   struct {
+			Attributes struct {
+				Titles map[string]string `json:"title"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&mangaRes); err != nil {
+		return "", err
+	}
+	if mangaRes.Result != "ok" {
+		return "", fmt.Errorf("Unexpected response")
+	}
+	for lang, t := range mangaRes.Data.Attributes.Titles {
+		title = t
+		if m.country == "" || m.country == lang {
+			break
+		}
+	}
+	return title, nil
+}
 
-	parts := util.TrimAndSplitURL(url)
-	chapterID, err := strconv.Atoi(parts[4])
+// Get a list of chapter IDs of a manga.
+func (m *Mangadex) getChapters(mangaID string) ([]string, error) {
+	url := fmt.Sprintf("https://api.mangadex.org/manga/%s/aggregate?", mangaID)
+	if m.country != "" {
+		url += fmt.Sprintf("&translatedLanguage[]=%s", m.country)
+	}
+	res, err := http.Get(url)
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
+	var chaptersRes struct {
+		Result  string `json:"result"`
+		Volumes map[string]struct {
+			Name     string `json:"volume"`
+			Chapters map[string]struct {
+				ID   string `json:"id"`
+				Name string `json:"chapter"`
+			} `json:"chapters"`
+		} `json:"volumes"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&chaptersRes); err != nil {
+		// This is not ideal. MangaDex returns an empty array (`[]`) when no volume
+		// exists and a `map[string]interface{}` otherwise.
+		return []string{}, nil
+	}
+	if chaptersRes.Result != "ok" {
+		return nil, fmt.Errorf("Unexpected response")
+	}
+	var ids []string
+	for _, v := range chaptersRes.Volumes {
+		for _, c := range v.Chapters {
+			url := fmt.Sprintf("https://mangadex.org/chapter/%s", c.ID)
+			ids = append(ids, url)
+		}
+	}
+	return ids, nil
+}
 
-	res, err := m.Client.Chapter(context.Background(), chapterID, nil)
+// Get a list of a chapters images.
+func (m *Mangadex) getChapter(chapterID string) (mangaID, volume, chapter, title string, images []string, err error) {
+	url := fmt.Sprintf("https://api.mangadex.org/chapter/%s", chapterID)
+	res, err := http.Get(url)
 	if err != nil {
-		return links, err
+		return "", "", "", "", nil, err
 	}
-
-	links = res.Images()
-
+	defer res.Body.Close()
+	var chapterRes struct {
+		Result string `json:"result"`
+		Data   struct {
+			Attributes struct {
+				Volume  string   `json:"volume"`
+				Chapter string   `json:"chapter"`
+				Title   string   `json:"title"`
+				Hash    string   `json:"hash"`
+				Data    []string `json:"data"`
+			} `json:"attributes"`
+			Relationships []struct {
+				ID   string `json:"id"`
+				Type string `json:"type"`
+			} `json:"relationships"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&chapterRes); err != nil {
+		return "", "", "", "", nil, err
+	}
+	if chapterRes.Result != "ok" {
+		return "", "", "", "", nil, fmt.Errorf("Unexpected response")
+	}
+	images = chapterRes.Data.Attributes.Data
+	for i, file := range images {
+		images[i] = fmt.Sprintf("https://uploads.mangadex.org/data/%s/%s", chapterRes.Data.Attributes.Hash, file)
+	}
 	if m.options.Debug {
-		m.options.Logger.Debug(fmt.Sprintf("Image Links found: %s", strings.Join(links, " ")))
+		m.options.Logger.Debug(fmt.Sprintf("Image Links found: %s", strings.Join(images, " ")))
 	}
-
-	return links, nil
+	for _, rel := range chapterRes.Data.Relationships {
+		if rel.Type == "manga" {
+			mangaID = rel.ID
+			break
+		}
+	}
+	return mangaID, chapterRes.Data.Attributes.Volume, chapterRes.Data.Attributes.Chapter, chapterRes.Data.Attributes.Title, images, nil
 }
 
 // RetrieveIssueLinks retrieve the issue links for the given comic.
@@ -63,32 +148,11 @@ func (m *Mangadex) RetrieveIssueLinks() ([]string, error) {
 	if len(parts) < 5 {
 		return nil, errors.New("URL not supported")
 	}
-	mangaID, err := strconv.Atoi(parts[4])
-	if err != nil {
-		return nil, err
-	}
 	switch parts[3] {
 	case "chapter":
 		return []string{m.options.URL}, nil
 	case "title":
-		cs, err := m.Client.MangaChapters(context.Background(), mangaID, nil)
-		if err != nil {
-			return nil, err
-		}
-		var urls []string
-		for _, c := range cs {
-			if m.country != "" && c.Language != m.country {
-				continue
-			}
-			urls = append(urls, fmt.Sprintf("%schapter/%d", m.baseURL, c.ID))
-		}
-		if len(urls) == 0 {
-			return nil, errors.New("no chapters found")
-		}
-		if m.options.Last {
-			urls = urls[:1]
-		}
-		return urls, nil
+		return m.getChapters(parts[4])
 	default:
 		return nil, errors.New("URL not supported")
 	}
@@ -97,30 +161,45 @@ func (m *Mangadex) RetrieveIssueLinks() ([]string, error) {
 // GetInfo extracts the basic info from the given url.
 func (m *Mangadex) GetInfo(url string) (string, string) {
 	parts := util.TrimAndSplitURL(url)
-	chapterID, err := strconv.Atoi(parts[4])
-	if err != nil {
+	if len(parts) < 5 {
 		return "", ""
 	}
-
-	chapterInfo, err := m.Client.Chapter(context.Background(), chapterID, nil)
-	if err != nil {
+	switch parts[3] {
+	case "chapter":
+		mangaID, volume, chapter, title, _, err := m.getChapter(parts[4])
+		if err != nil {
+			return "", ""
+		}
+		chapterTitle := fmt.Sprintf("Vol %s Chapter %s", volume, chapter)
+		if title != "" {
+			chapterTitle += fmt.Sprintf(", %s", title)
+		}
+		mangaTitle, err := m.getManga(mangaID)
+		if err != nil {
+			return "", chapterTitle
+		}
+		return mangaTitle, chapterTitle
+	case "title":
+		mangaTitle, err := m.getManga(parts[4])
+		if err != nil {
+			return "", ""
+		}
+		return mangaTitle, ""
+	default:
 		return "", ""
 	}
-
-	mangaID := chapterInfo.MangaID
-	mangaInfo, err := m.Client.Manga(context.Background(), mangaID, nil)
-	if err != nil {
-		return "", ""
-	}
-
-	issueNumber := fmt.Sprintf("Vol %s Chapter %s, %s", chapterInfo.Volume, chapterInfo.Chapter, chapterInfo.Title)
-
-	return mangaInfo.Title, issueNumber
 }
 
 // Initialize loads links and metadata from mangadex
 func (m *Mangadex) Initialize(comic *core.Comic) error {
-	links, err := m.getLinks(comic.URLSource)
-	comic.Links = links
-	return err
+	parts := util.TrimAndSplitURL(comic.URLSource)
+	if len(parts) < 4 {
+		return fmt.Errorf("URL not supported")
+	}
+	_, _, _, _, images, err := m.getChapter(parts[4])
+	if err != nil {
+		return err
+	}
+	comic.Links = images
+	return nil
 }


### PR DESCRIPTION
Hi,

I've decided to archive my MangaDex client since I personally would not use most of the new API and I don't have the time to support it on future updates if needed. Instead I implemented a subset of it directly in the comics-downloader.

Please see if you're ok with this (a little rushed) implementation. Note that the `-last` flag currently does not work. 