### PR TITLE
Add support for renaming comic/manga

### DIFF
--- a/cmd/downloader/main.go
+++ b/cmd/downloader/main.go
@@ -24,6 +24,7 @@ var (
 	// manga/comic final output
 	forceAspect bool
 	format      string
+	customComicName string
 	// force only issue number filenames
 	issueNumberNameOnly bool
 	// url source
@@ -52,6 +53,7 @@ func init() {
 	flag.StringVar(&country, "country", "", "Set the country to retrieve a manga, Used by MangaDex which uses ISO 3166-1 codes")
 	flag.BoolVar(&forceAspect, "force-aspect", false, "Force images to A4 Portrait aspect ratio")
 	flag.StringVar(&format, "format", "pdf", "Comic format output, supported formats are pdf,epub,cbr,cbz")
+	flag.StringVar(&customComicName, "custom-comic-name", "", "Use a custom name for the comic output.")
 	flag.StringVar(&imagesFormat, "images-format", "jpg", "To use with `images-only` flag, choose the image format, available png,jpeg,img")
 	flag.BoolVar(&issueNumberNameOnly, "issue-number-only", false, "Force only saving with issue number instead of chapter name + issue number.")
 	flag.StringVar(&url, "url", "", "Comic URL or Comic URLS by separating each site with a comma without the use of spaces")
@@ -80,8 +82,9 @@ func main() {
 		URL:                 url,
 		ForceAspect:         forceAspect,
 		Format:              format,
+		CustomComicName:     customComicName,
 		Daemon:              daemon,
-		DaemonTimeout:             daemonTimeout,
+		DaemonTimeout:       daemonTimeout,
 		OutputFolder:        outputFolder,
 		CreateDefaultPath:   createDefaultPath,
 		IssuesRange:         issuesRange,

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	ImagesFormat        string
 	Country             string
 	Format              string
+	CustomComicName     string
 	ForceAspect         bool
 	OutputFolder        string
 	CreateDefaultPath   bool

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -33,6 +33,9 @@ func initializeCollection(issues []string, options *config.Options, base BaseSit
 	for _, url := range issues {
 		name, issueNumber := base.GetInfo(url)
 		name = util.Parse(name)
+		if len(options.CustomComicName) > 0 {
+			name = options.CustomComicName
+		}
 		issueNumber = util.Parse(issueNumber)
 
 		if notInIssuesRange(issueNumber, startRange, endRange) {

--- a/pkg/sites/loader_test.go
+++ b/pkg/sites/loader_test.go
@@ -39,6 +39,37 @@ func TestSiteLoaderMangatown(t *testing.T) {
 	assert.Equal(t, 20, len(comic.Links))
 }
 
+func TestCustomComicName(t *testing.T) {
+	url := "https://www.mangatown.com/manga/naruto/v63/c693/"
+	outputFolder := filepath.Dir(os.Args[0])
+
+	options := &config.Options{
+		All:              false,
+		Last:             false,
+		ImagesOnly:       false,
+		Source:           "www.mangatown.com",
+		URL:              url,
+		Format:           "pdf",
+		ImagesFormat:     "png",
+		CustomComicName:  "Naruto",
+		OutputFolder: outputFolder,
+	}
+
+	collection, err := LoadComicFromSource(options)
+
+	assert.Nil(t, err)
+	assert.Equal(t, len(collection), 1)
+
+	comic := collection[0]
+
+	assert.Equal(t, "www.mangatown.com", comic.Source)
+	assert.Equal(t, url, comic.URLSource)
+	assert.Equal(t, "Naruto", comic.Name)
+	assert.Equal(t, "c693", comic.IssueNumber)
+	assert.Equal(t, 20, len(comic.Links))
+}
+
+
 //func TestSiteLoaderMangareader(t *testing.T) {
 //url := "https://www.mangareader.net/naruto/700"
 //outputFolder := filepath.Dir(os.Args[0])


### PR DESCRIPTION
Add support for renaming comic/manga to a different name,
this can be usefull if for example one wants to change the
casing from lowercase to uppercase of a comic or rename
a manga from a Japanese to English name.