### PR TITLE
Prevent out of memory

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"runtime"
 
 	"golang.org/x/sync/errgroup"
 
@@ -308,6 +309,7 @@ func (comic *Comic) DownloadImages(options *config.Options) (string, error) {
 
 		})
 	}
+	runtime.GC()
 
 	if err := g.Wait(); err != nil {
 		return dir, err


### PR DESCRIPTION
When downloading a large set of comics (for example Spawn) on a
raspberry pi comics-downloader would crash due to running out of memory.
Adding a call to garbage collection in the loop for downloading images
prevents this from happening.