### PR TITLE
support float ranges

### DIFF
--- a/internal/flag/parser/range.go
+++ b/internal/flag/parser/range.go
@@ -9,13 +9,13 @@ import (
 
 // ParseIssuesRange the range of issues.
 // Format [start-end].
-func ParseIssuesRange(rng string) (int, int, error) {
+func ParseIssuesRange(rng string) (float64, float64, error) {
 	values := strings.Split(rng, "-")
 	if len(values) != 2 {
 		return 0, 0, errors.New("wrong range format")
 	}
 
-	startRange, err := strconv.Atoi(values[0])
+	startRange, err := strconv.ParseFloat(values[0], 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("wrong the start range value: %v", err)
 	}
@@ -24,7 +24,7 @@ func ParseIssuesRange(rng string) (int, int, error) {
 		return 0, 0, errors.New("the start range value must not be zero")
 	}
 
-	endRange, err := strconv.Atoi(values[1])
+	endRange, err := strconv.ParseFloat(values[1], 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("wrong the end range value: %v", err)
 	}

--- a/internal/flag/parser/range_test.go
+++ b/internal/flag/parser/range_test.go
@@ -9,13 +9,15 @@ import (
 func TestParseIssuesRange(t *testing.T) {
 	tt := []struct {
 		input         string
-		expectedStart int
-		expectedEnd   int
+		expectedStart float64
+		expectedEnd   float64
 		hasError      bool
 	}{
 		{"1-1", 1, 1, false},
 		{"1-5", 1, 5, false},
 		{"3-9", 3, 9, false},
+		{"3.1-9.5", 3.1, 9.5, false},
+		{"3.-9.5", 3, 9.5, false},
 		{"12-123", 12, 123, false},
 		{"0-0", 0, 0, true},
 		{"0-1", 0, 0, true},

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -20,7 +20,7 @@ func initializeCollection(issues []string, options *config.Options, base BaseSit
 		return collection, errors.New("No issues found")
 	}
 
-	var startRange, endRange int
+	var startRange, endRange float64
 	if options.All && options.IssuesRange != "" {
 		start, end, err := parser.ParseIssuesRange(options.IssuesRange)
 		if err != nil {
@@ -64,9 +64,9 @@ func initializeCollection(issues []string, options *config.Options, base BaseSit
 	return collection, nil
 }
 
-var onlyNumbers = regexp.MustCompile("[^0-9]+")
+var onlyNumbers = regexp.MustCompile("[^0-9]+[^.][^0-9]+")
 
-func notInIssuesRange(issueNumber string, start, end int) bool {
+func notInIssuesRange(issueNumber string, start, end float64) bool {
 	if start == 0 || end == 0 {
 		return false
 	}
@@ -76,7 +76,7 @@ func notInIssuesRange(issueNumber string, start, end int) bool {
 		return true
 	}
 
-	number, err := strconv.Atoi(normalizedNumber)
+	number, err := strconv.ParseFloat(normalizedNumber, 64)
 	if err != nil {
 		return true
 	}

--- a/pkg/sites/loader_test.go
+++ b/pkg/sites/loader_test.go
@@ -176,3 +176,25 @@ func TestIssuesRange(t *testing.T) {
 	assert.Contains(t, issues, "chapter-6")
 	assert.Contains(t, issues, "chapter-7")
 }
+
+func TestFloatIssuesRange(t *testing.T) {
+	tt := []struct {
+		input       string
+		start       float64
+		end         float64
+		returnValue bool
+	}{
+		{"1", 1, 1, false},
+		{"19", 20, 21, true},
+		{"20", 20, 21, false},
+		{"20.5", 20, 21, false},
+		{"21", 20, 21, false},
+		{"22", 20, 21, true},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.input, func(t *testing.T) {
+			assert.Equal(t, notInIssuesRange(tc.input, tc.start, tc.end), tc.returnValue)
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -54,7 +54,7 @@ func IsValueInSlice(valueToCheck string, values []string) bool {
 // Parse escapes characters
 func Parse(s string) string {
 	replacer := strings.NewReplacer(
-		".", " ",
+		"\"", "",
 		"/", "_",
 		"[", "",
 		"]", "",


### PR DESCRIPTION
Changes handling of ranges from `int`s to `float64`s, as a fix for #94.
Also removed dots (`.`) from escaped characters and added double quotes `"`(can't be in file/directory names on Windows)