### PR TITLE
Makefile: remove separate linux build targets for different architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ osx-build: # Creates Mac OSX
 windows-build: # Creates Windows
 	@GOOS=windows GOARCH=amd64 go build -o build/comics-downloader.exe ./cmd/downloader
 
-linux-build: # Creates Linux
-	@GOOS=linux GOARCH=amd64 go build -o build/comics-downloader ./cmd/downloader
+linux-build: # Creates Linux to host architecture
+	@GOOS=linux go build -o build/comics-downloader ./cmd/downloader
 
 linux-arm-build: # Creates Linux ARM
 	@GOOS=linux GOARCH=arm go build -o build/comics-downloader-linux-arm ./cmd/downloader


### PR DESCRIPTION
This makes packaging on linux much harder. Go build already detects the correct
architecture. Using this patch, you can create and cross compile binaries for
linux as such:

pinephone:~/code/comics-downloader$ export GOARCH=arm64
pinephone:~/code/comics-downloader$ rm -rf build/
pinephone:~/code/comics-downloader$ make linux-build
pinephone:~/code/comics-downloader$ export GOARCH=amd64
pinephone:~/code/comics-downloader$ rm -rf build/
pinephone:~/code/comics-downloader$ make linux-build

closes #103