### PR TITLE
[Draft] Multiple  urls per site

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Girbons/comics-downloader
 
-go 1.17
+go 1.18
 
 require (
 	fyne.io/fyne v1.4.3

--- a/pkg/sites/loader.go
+++ b/pkg/sites/loader.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Girbons/comics-downloader/pkg/config"
 	"github.com/Girbons/comics-downloader/pkg/core"
 	"github.com/Girbons/comics-downloader/pkg/util"
+	"golang.org/x/exp/slices"
 )
 
 func initializeCollection(issues []string, options *config.Options, base BaseSite) ([]*core.Comic, error) {
@@ -86,6 +87,8 @@ func notInIssuesRange(issueNumber string, start, end float64) bool {
 
 // LoadComicFromSource will return an `comic` instance initialized based on the source
 func LoadComicFromSource(options *config.Options) ([]*core.Comic, error) {
+	// this probably needs to land in the comicextra.go
+	const supportedComicExtra := []string{"ww1.comciextra.com", "www.comicextra.com"}
 	var (
 		base       BaseSite
 		issues     []string
@@ -93,10 +96,10 @@ func LoadComicFromSource(options *config.Options) ([]*core.Comic, error) {
 		err        error
 	)
 
-	switch options.Source {
+	switch sourceUrl := options.Source; sourceUrl {
 	case "readcomiconline.li":
 		base = NewReadComiconline(options)
-	case "www.comicextra.com":
+	case supportedComicExtra.contains(soureUrl):
 		base = NewComicextra(options)
 	case "mangareader.tv":
 		base = NewMangareader(options)


### PR DESCRIPTION
SPOILER: Not a go lang dev

WHY: Sites will redirect to another url and tool will fail. Both servers are often valid when using the tool, one will always fail though.

WHAT: 
1. Upgrade golang to 1.18 - slices library has the contains function
2. Add draft of switch-case to support multiple urls.